### PR TITLE
Return only the actually recorded data.

### DIFF
--- a/src/dwfpy/analog_recorder.py
+++ b/src/dwfpy/analog_recorder.py
@@ -200,7 +200,8 @@ class AnalogRecorder:
 
     def _normalize_ring_buffer(self, buffer: ctypes.Array, index: int):
         array = np.array(buffer)
-        if index + self._total_samples <= len(array):
-            return array[index:self._total_samples]
+        total_samples = min(self._total_samples, len(array))
+        if index >= total_samples:
+            return array[index-total_samples:index]
         else:
-            np.concatenate([array[index:], array[:index+self._total_samples-len(array)]])
+            np.concatenate([array[index-total_samples:], array[:index]])

--- a/src/dwfpy/analog_recorder.py
+++ b/src/dwfpy/analog_recorder.py
@@ -204,4 +204,4 @@ class AnalogRecorder:
         if index >= total_samples:
             return array[index-total_samples:index]
         else:
-            np.concatenate([array[index-total_samples:], array[:index]])
+            return np.concatenate([array[index-total_samples:], array[:index]])

--- a/src/dwfpy/analog_recorder.py
+++ b/src/dwfpy/analog_recorder.py
@@ -142,6 +142,7 @@ class AnalogRecorder:
             self._requested_samples = self._buffer_size
 
             self._buffer_index = 0
+            self._total_samples = 0
 
             self._data_buffers = []
             for channel in self._module.channels:
@@ -197,7 +198,9 @@ class AnalogRecorder:
         pointer = ctypes.byref(c_buffer, index * ctypes.sizeof(ctypes.c_double))
         return ctypes.cast(pointer, ctypes.POINTER(ctypes.c_double))
 
-    @staticmethod
-    def _normalize_ring_buffer(buffer: ctypes.Array, index: int):
+    def _normalize_ring_buffer(self, buffer: ctypes.Array, index: int):
         array = np.array(buffer)
-        return array if index == 0 else np.concatenate([array[index:], array[:index]])
+        if index + self._total_samples <= len(array):
+            return array[index:self._total_samples]
+        else:
+            np.concatenate([array[index:], array[:index+self._total_samples-len(array)]])


### PR DESCRIPTION
Currently, the `data_samples` are always of the requested length, regardless of the number of samples actually recorded. If recording is stopped early (e.g if the user callback returns false early), then the returned data_samples will have extra junk (0s?) at the *beginning*. This change makes sure to only keep the actual length of samples.